### PR TITLE
Add twitter link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,6 +32,8 @@ social:
   - title: apply
     icon: check
     url: https://forms.gle/bRWLvGCEx7BC9j6s9
+  - title: twitter
+    url: https://twitter.com/the_manks
   - title: contact
     icon: envelope
     url: mailto:info@manks.org


### PR DESCRIPTION
Adding link to The Manks Official twitter account under the social section of the site.